### PR TITLE
Use inline sed for replace logic to avoid file system race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Created by https://www.toptal.com/developers/gitignore/api/latex,linux,macos,windows,microsoftoffice,visualstudiocode
-# Edit at https://www.toptal.com/developers/gitignore?templates=latex,linux,macos,windows,microsoftoffice,visualstudiocode
+# Created by https://www.toptal.com/developers/gitignore/api/latex,linux,macos,windows,microsoftoffice,visualstudiocode,python
+# Edit at https://www.toptal.com/developers/gitignore?templates=latex,linux,macos,windows,microsoftoffice,visualstudiocode,python
 
 ### LaTeX ###
 ## Core latex/pdflatex auxiliary files:
@@ -333,8 +333,7 @@ TSWLatexianTemp*
 .LSOverride
 
 # Icon must end with two \r
-Icon
-
+Icon
 
 # Thumbnails
 ._*
@@ -379,6 +378,177 @@ Backup of *.doc*
 
 # Visio autosave temporary files
 *.~vsd*
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
 
 ### VisualStudioCode ###
 .vscode/*
@@ -425,4 +595,4 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# End of https://www.toptal.com/developers/gitignore/api/latex,linux,macos,windows,microsoftoffice,visualstudiocode
+# End of https://www.toptal.com/developers/gitignore/api/latex,linux,macos,windows,microsoftoffice,visualstudiocode,python

--- a/tools/convert.sh
+++ b/tools/convert.sh
@@ -282,9 +282,8 @@ if ! test -f "${mdOutFile}"; then
 fi
 
 if [ -f "$replaceFilePath" ]; then
-  while IFS="=" read -r key value; do
-    sed -i -e "s|${key}|${value}|g" $mdOutFile
-  done < <(jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' $replaceFilePath)
+  jq -r 'to_entries | map("\(.key)/\(.value|tostring)") | .[]' "$replaceFilePath" |
+    xargs -I {} sed -i 's/{}/g' "$mdOutFile"
 fi
 
 mdContent=$(cat "${mdOutFile}")

--- a/tools/convert.sh
+++ b/tools/convert.sh
@@ -281,11 +281,13 @@ if ! test -f "${mdOutFile}"; then
   exit 1
 fi
 
-if [ ! -f "$replaceFilePath" ]; then
-  error '' "Unable to find replace file $replaceFilePath" 1
-else
-  jq -r 'to_entries | map("\(.key)/\(.value|tostring)") | .[]' "$replaceFilePath" |
-    xargs -I {} sed -i 's/{}/g' "$mdOutFile"
+if test -n "${ReplaceFile}"; then
+  if [ ! -f "$replaceFilePath" ]; then
+    error '' "Unable to find replace file $replaceFilePath" 1
+  else
+    jq -r 'to_entries | map("\(.key)/\(.value|tostring)") | .[]' "$replaceFilePath" |
+      xargs -I {} sed -i 's/{}/g' "$mdOutFile"
+  fi
 fi
 
 mdContent=$(cat "${mdOutFile}")

--- a/tools/convert.sh
+++ b/tools/convert.sh
@@ -281,7 +281,9 @@ if ! test -f "${mdOutFile}"; then
   exit 1
 fi
 
-if [ -f "$replaceFilePath" ]; then
+if [ ! -f "$replaceFilePath" ]; then
+  error '' "Unable to find replace file $replaceFilePath" 1
+else
   jq -r 'to_entries | map("\(.key)/\(.value|tostring)") | .[]' "$replaceFilePath" |
     xargs -I {} sed -i 's/{}/g' "$mdOutFile"
 fi


### PR DESCRIPTION
### Summary
When running markdown2pdf with a long replace.json the replace logic is most of the time not applied. Changing replace logic in convert.sh seems to solve the issue.

### Details
- The current script rewrites the entire file to disk for every sed invocation leading to inconsistent behavior and failed replacements. Invoking sed with --inline avoids this problem. The script still writes to disk once per replace.json entry but it solves the problem for now.
- It's nice to use virtualenv or similar to run markdown2pdf locally, adding
  python-related files to .gitignore makes this less of a hassle

### Steps to reproduce

* See attached reproduction script below

### Changes
- Change sed replace logic to inline (sed -i)
- Add python files to .gitignore


### Attachments

Reproduction script:

1. Writes sample markdown, replace.json and document order to disk
2. Downloads required files (markdown2pdf@v3.0.2)
3. Downloads patched convert.sh from ottolote/markdown2pdf@main
4. Generates two pdfs: patched-convert.pdf and unpatched-convert.pdf

```bash
# Write to document.order
cat <<EOF > "document.order"
sample.md
EOF

# Write to replace.json
cat <<EOF > "replace.json"
{
  "{Dish Name}": "GPT fruit pie",
  "{ingredient1}": "apple",
  "{ingredient2}": "banana",
  "{ingredient3}": "cherry",
  "{ingredient4}": "date",
  "{ingredient5}": "elderberry",
  "{ingredient6}": "fig",
  "{ingredient7}": "grape",
  "{ingredient8}": "honeydew",
  "{ingredient9}": "kiwi",
  "{ingredient10}": "lemon",
  "{ingredient11}": "mango",
  "{ingredient12}": "nectarine",
  "{ingredient13}": "orange"
}
EOF

# Write to sample.md
cat <<EOF > "sample.md"
# {Dish Name}

## Ingredients

- {ingredient1}
- {ingredient2}
- {ingredient3}
- {ingredient4}
- {ingredient5}
- {ingredient6}
- {ingredient7}
- {ingredient8}
- {ingredient9}
- {ingredient10}
- {ingredient11}
- {ingredient12}
- {ingredient13}

## Directions

1. Preheat your oven to 350 degrees.
2. In a large bowl, whisk together {ingredient1}, {ingredient2}, {ingredient3}, and {ingredient4} to form the base of the {Dish Name}.
3. Mix {ingredient5}, {ingredient6}, and {ingredient7} in a separate bowl to create the flavor profile.
4. Gradually blend the flavor profile mixture into the base.
5. Gently fold in {ingredient8} to add texture.
6. Pour the batter into a prepared pan.
7. Bake for {ingredient10} minutes or until done.
8. Let the {Dish Name} cool and garnish with {ingredient11}.
9. Serve your {Dish Name} with a side of {ingredient12} and a drizzle of {ingredient13}.

Enjoy your {Dish Name}!
EOF



# Download files
files=(
  "convert.sh"
  designdoc.tex
  designdoc-cover.png
  designdoc-logo.png
)
for file in "${files[@]}"; do
  uri="https://github.com/innofactororg/markdown2pdf/raw/v3.0.2/tools/${file}"
  HTTP_CODE=$(curl -sSL --remote-name --retry 4 \
    --write-out "%{response_code}" \
    --header 'Accept: application/vnd.github.raw' "${uri}"
  )
  if [ "${HTTP_CODE}" -lt 200 ] || [ "${HTTP_CODE}" -gt 299 ]; then
    echo "##[error]Unable to get ${uri}! Response code: ${HTTP_CODE}"
    # exit 1
  fi
done

# Download patched convert.sh
curl -sSL --output patched-convert.sh --retry 4 \
  --header 'Accept: application/vnd.github.raw' \
  "https://github.com/ottolote/markdown2pdf/raw/main/tools/convert.sh"

shared_params='-a GPT4 -d "A dish made by GPT4" -f ./ -force true -h 400 -l 400 -o document.order -p "GPT4 Chef Demo" -r replace.json -s "A markdown2pdf demo" -t "GPT Fruit Pie" --template designdoc'

chmod +x ./convert.sh
bash -c "./convert.sh $shared_params -out unpatched-convert.pdf"

chmod +x ./patched-convert.sh
bash -c "./patched-convert.sh $shared_params -out patched-convert.pdf"
```
