### PR TITLE
fix: update the actions cache version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
         echo '::endgroup::'
 
     - name: Cache Tex Live
-      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+      uses: actions/cache@v4 # v4.2 or later due to 2025-02 deprecation
       with:
         key: ${{ runner.os }}-texlive
         path: /opt/texlive


### PR DESCRIPTION
The Actions/Cache was recoded, and older versions (including pinned) were deprecated
updating to allow v4.2 or later, which is mandatory post Feb 1st 2025.